### PR TITLE
Drop data stream before waiting close code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async_ftp"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Daniel García <dani-garcia@users.noreply.github.com>", "Matt McCoy <mattnenterprise@yahoo.com>"]
 documentation = "https://docs.rs/async_ftp/"
 repository = "https://github.com/dani-garcia/rust_async_ftp"

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -453,6 +453,7 @@ impl FtpStream {
                 Err(err) => return Err(FtpError::ConnectionError(err)),
             };
         }
+        drop(data_stream);
 
         self.read_response_in(close_code).await?;
         Ok(lines)


### PR DESCRIPTION
I encountered an issue while listing files from an FTP server -- the close code is never send back just because the data connection is open. Just dropping `data_stream` solves the issue.

I took the freedom to bump the path version, if it is not a problem.