### PR TITLE
Split lines according to both dos and unix conventions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ chrono = "0.4.11"
 tokio = { version = "0.2.21", features = ["tcp", "dns", "io-util"] }
 tokio-rustls = { version = "0.13.1", optional = true }
 pin-project = "0.4.17"
+
+[dev-dependencies.tokio]
+version = "0.2.21"
+features = [ "macros", "stream", "io-util" ]


### PR DESCRIPTION
The current implementation could be simpler, but it would need the `stream` feature from `tokio`. In this way there is no compile-time overhead and the code should be understandable.

Closes #3 