### PR TITLE
Update to Tokio 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,11 @@ lazy_static = "1.4.0"
 regex = "1.3.9"
 chrono = "0.4.11"
 
-tokio = { version = "0.2.21", features = ["tcp", "dns", "io-util"] }
-tokio-rustls = { version = "0.13.1", optional = true }
-pin-project = "0.4.17"
+tokio = { version = "0.3.1", features = ["net", "io-util"] }
+tokio-rustls = { version = "0.20.0", optional = true }
+pin-project = "1.0.0"
 
-[dev-dependencies.tokio]
-version = "0.2.21"
-features = [ "macros", "stream", "io-util" ]
+[dev-dependencies]
+tokio = { version = "0.3.1", features = ["macros", "stream", "rt"] }
+tokio-util = { version = "0.4.0", features = ["io"] }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async_ftp"
-version = "4.0.4"
+version = "5.0.0"
 authors = ["Daniel García <dani-garcia@users.noreply.github.com>", "Matt McCoy <mattnenterprise@yahoo.com>"]
 documentation = "https://docs.rs/async_ftp/"
 repository = "https://github.com/dani-garcia/rust_async_ftp"
@@ -26,11 +26,11 @@ lazy_static = "1.4.0"
 regex = "1.3.9"
 chrono = "0.4.11"
 
-tokio = { version = "0.3.1", features = ["net", "io-util"] }
-tokio-rustls = { version = "0.20.0", optional = true }
+tokio = { version = "1.0.1", features = ["net", "io-util"] }
+tokio-rustls = { version = "0.22.0", optional = true }
 pin-project = "1.0.0"
 
 [dev-dependencies]
-tokio = { version = "0.3.1", features = ["macros", "stream", "rt"] }
-tokio-util = { version = "0.4.0", features = ["io"] }
-
+tokio = { version = "1.0.1", features = ["macros", "rt"] }
+tokio-util = { version = "0.6.0", features = ["io"] }
+tokio-stream = "0.1.0"

--- a/examples/connecting.rs
+++ b/examples/connecting.rs
@@ -26,7 +26,7 @@ async fn test_ftp(addr: &str, user: &str, pass: &str) -> Result<(), FtpError> {
 fn main() {
     let future = test_ftp("172.25.82.139", "anonymous", "rust-ftp@github.com");
 
-    tokio::runtime::Builder::new()
+    tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .unwrap()

--- a/src/data_stream.rs
+++ b/src/data_stream.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 #[cfg(feature = "secure")]
 use tokio_rustls::client::TlsStream;
@@ -47,8 +47,8 @@ impl AsyncRead for DataStream {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         match self.project() {
             DataStreamProj::Tcp(stream) => stream.poll_read(cx, buf),
             #[cfg(feature = "secure")]

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -617,12 +617,12 @@ impl FtpStream {
 #[cfg(test)]
 mod tests {
     use super::FtpStream;
-    use tokio::{stream};
+    use tokio_stream::once;
     use tokio_util::io::StreamReader;
 
     #[tokio::test]
     async fn list_command_dos_newlines() {
-        let data_stream = StreamReader::new(stream::once(Ok::<_, std::io::Error>(
+        let data_stream = StreamReader::new(once(Ok::<_, std::io::Error>(
             b"Hello\r\nWorld\r\n\r\nBe\r\nHappy\r\n" as &[u8]
         )));
 
@@ -637,7 +637,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_command_unix_newlines() {
-        let data_stream =  StreamReader::new(stream::once(Ok::<_, std::io::Error>(b"Hello\nWorld\n\nBe\nHappy\n" as &[u8])));
+        let data_stream =  StreamReader::new(once(Ok::<_, std::io::Error>(b"Hello\nWorld\n\nBe\nHappy\n" as &[u8])));
 
         assert_eq!(
             FtpStream::get_lines_from_stream(data_stream).await.unwrap(),

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -617,11 +617,12 @@ impl FtpStream {
 #[cfg(test)]
 mod tests {
     use super::FtpStream;
-    use tokio::{io::stream_reader, stream};
+    use tokio::{stream};
+    use tokio_util::io::StreamReader;
 
     #[tokio::test]
     async fn list_command_dos_newlines() {
-        let data_stream = stream_reader(stream::once(Ok(
+        let data_stream = StreamReader::new(stream::once(Ok::<_, std::io::Error>(
             b"Hello\r\nWorld\r\n\r\nBe\r\nHappy\r\n" as &[u8]
         )));
 
@@ -636,7 +637,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_command_unix_newlines() {
-        let data_stream = stream_reader(stream::once(Ok(b"Hello\nWorld\n\nBe\nHappy\n" as &[u8])));
+        let data_stream =  StreamReader::new(stream::once(Ok::<_, std::io::Error>(b"Hello\nWorld\n\nBe\nHappy\n" as &[u8])));
 
         assert_eq!(
             FtpStream::get_lines_from_stream(data_stream).await.unwrap(),

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,20 +1,14 @@
-FROM i386/ubuntu:latest
+FROM ubuntu:latest
 
-RUN apt-get update -qq &&\
-    apt-get install -yqq vsftpd
+RUN apt update && apt install -y vsftpd
 
-RUN mkdir -p /var/run/vsftpd/empty &&\
-    useradd -s /bin/bash -d /home/ftp -m -c "Doe ftp user" -g ftp Doe &&\
-    echo "Doe:mumble"| chpasswd &&\
-    echo "listen=yes\n\
-anon_root=/home/ftp\n\
-local_enable=yes\n\
-local_umask=022\n\
-pasv_enable=YES\n\
-pasv_min_port=65000\n\
-pasv_max_port=65010\n\
-write_enable=yes\n\
-log_ftp_protocol=yes" > /etc/vsftpd.conf &&\
-    echo "/etc/init.d/vsftpd start" | tee -a /etc/bash.bashrc
+RUN useradd --home-dir /home/ftp --create-home --groups ftp Doe
+RUN echo "Doe:mumble" | chpasswd
+
+RUN cp /etc/vsftpd.conf /etc/vsftpd.conf.orig
+RUN echo "write_enable=yes\nlog_ftp_protocol=yes" > /etc/vsftpd.conf
+RUN cat /etc/vsftpd.conf.orig >> /etc/vsftpd.conf
+    
+RUN echo "/etc/init.d/vsftpd start" | tee -a /etc/bash.bashrc
 
 CMD ["/bin/bash"]

--- a/tests/ftp-server.sh
+++ b/tests/ftp-server.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
-# run the ftp server instance in detached mode (in the background)
-# but also with TTY and interactive mode, so we can attach to it if we want to
-docker run -dti --privileged -p 21:21 -p 65000-65010:65000-65010 ftp-server
+# Build the docker image
+docker build -t ftp-server .
+
+# run the ftp server instance
+docker run --rm --name ftp-server -ti --net=host ftp-server

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -36,7 +36,7 @@ fn test_ftp() {
         Ok(())
     };
 
-    let result: Result<(), FtpError> = tokio::runtime::Builder::new()
+    let result: Result<(), FtpError> = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .unwrap()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,7 +5,7 @@ use std::io::Cursor;
 #[test]
 fn test_ftp() {
     let future = async {
-        let mut ftp_stream = FtpStream::connect("172.25.82.139:21").await?;
+        let mut ftp_stream = FtpStream::connect("192.168.1.60:21").await?;
         let _ = ftp_stream.login("Doe", "mumble").await?;
 
         ftp_stream.mkdir("test_dir").await?;


### PR DESCRIPTION
Can be tested adding this to Cargo.toml:
```toml
[patch.crates-io]
async_ftp = { git = 'https://github.com/dani-garcia/rust_async_ftp', branch = 'tokio03' }
```