### PR TITLE
Make FtpStream::retr error return type generic

### DIFF
--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -337,10 +337,11 @@ impl FtpStream {
     ///   assert!(conn.rm("retr.txt").await.is_ok());
     /// };
     /// ```
-    pub async fn retr<F, T, P>(&mut self, filename: &str, reader: F) -> Result<T>
+    pub async fn retr<F, T, P, E>(&mut self, filename: &str, reader: F) -> std::result::Result<T, E>
     where
         F: Fn(BufReader<DataStream>) -> P,
-        P: std::future::Future<Output = Result<T>>,
+        P: std::future::Future<Output = std::result::Result<T, E>>,
+        E: From<FtpError>,
     {
         let retr_command = format!("RETR {}\r\n", filename);
 


### PR DESCRIPTION
The change should not be breaking, except for foreign `compile-fail` doctests that now could compile.

Closes #5 