### PR TITLE
Add resume functionality

### DIFF
--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -289,7 +289,7 @@ impl FtpStream {
         Ok(())
     }
     /// Sets the byte from which the transfer is to be restarted.
-    pub fn restart_from(&mut self, offset: u64) -> crate::Result<()> {
+    pub async fn restart_from(&mut self, offset: u64) -> Result<()> {
         let rest_command = format!("REST {}\r\n", offset.to_string());
         self.write_str(&rest_command)?;
         self.read_response(status::REQUEST_FILE_PENDING).map(|_| ())

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -292,7 +292,7 @@ impl FtpStream {
     pub async fn restart_from(&mut self, offset: u64) -> Result<()> {
         let rest_command = format!("REST {}\r\n", offset.to_string());
         self.write_str(&rest_command).await?;
-        self.read_response(status::REQUEST_FILE_PENDING).map(|_| ())
+        self.read_response(status::REQUEST_FILE_PENDING).await.map(|_| ())
     }
 
     /// Retrieves the file name specified from the server.

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -291,7 +291,7 @@ impl FtpStream {
     /// Sets the byte from which the transfer is to be restarted.
     pub async fn restart_from(&mut self, offset: u64) -> Result<()> {
         let rest_command = format!("REST {}\r\n", offset.to_string());
-        self.write_str(&rest_command)?;
+        self.write_str(&rest_command).await?;
         self.read_response(status::REQUEST_FILE_PENDING).map(|_| ())
     }
 

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -288,6 +288,12 @@ impl FtpStream {
         self.read_response(status::CLOSING).await?;
         Ok(())
     }
+    /// Sets the byte from which the transfer is to be restarted.
+    pub fn restart_from(&mut self, offset: u64) -> crate::Result<()> {
+        let rest_command = format!("REST {}\r\n", offset.to_string());
+        self.write_str(&rest_command)?;
+        self.read_response(status::REQUEST_FILE_PENDING).map(|_| ())
+    }
 
     /// Retrieves the file name specified from the server.
     /// This method is a more complicated way to retrieve a file.


### PR DESCRIPTION
This PR implements the `REST` FTP verb, enabling resume of partially downloaded files.