### PR TITLE
Maintenance commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ keywords = ["ftp"]
 categories = ["network-programming"]
 
 [features]
-# default = ["secure"]
-
 # Enable support of FTPS which requires openssl
 secure = ["tokio-rustls"]
 
@@ -22,15 +20,14 @@ secure = ["tokio-rustls"]
 debug_print = []
 
 [dependencies]
-lazy_static = "1.4.0"
-regex = "1.3.9"
 chrono = "0.4.11"
-
-tokio = { version = "1.0.1", features = ["net", "io-util"] }
-tokio-rustls = { version = "0.23.0", optional = true }
+lazy_static = "1.4.0"
 pin-project = "1.0.0"
+regex = "1.3.9"
+tokio = { version = "1.0", features = ["net", "io-util"] }
+tokio-rustls = { version = "0.24", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0.1", features = ["macros", "rt"] }
-tokio-util = { version = "0.6.0", features = ["io"] }
 tokio-stream = "0.1.0"
+tokio-util = { version = "0.6.0", features = ["io"] }

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -84,7 +84,11 @@ impl FtpStream {
     /// };
     /// ```
     #[cfg(feature = "secure")]
-    pub async fn into_secure(mut self, config: ClientConfig, domain: ServerName) -> Result<FtpStream> {
+    pub async fn into_secure(
+        mut self,
+        config: ClientConfig,
+        domain: ServerName,
+    ) -> Result<FtpStream> {
         // Ask the server to start securing data.
         self.write_str("AUTH TLS\r\n").await?;
         self.read_response(status::AUTH_OK).await?;
@@ -553,9 +557,9 @@ impl FtpStream {
                     caps[5].parse::<u32>().unwrap(),
                     caps[6].parse::<u32>().unwrap(),
                 );
-                Ok(Some(
-                    Utc.ymd(year, month, day).and_hms(hour, minute, second),
-                ))
+                Ok(Utc
+                    .with_ymd_and_hms(year, month, day, hour, minute, second)
+                    .latest())
             }
             None => Ok(None),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! ### FTPS Usage
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use std::convert::TryFrom;
 //! use std::path::Path;
 //! use async_ftp::FtpStream;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,7 +5,7 @@ use std::io::Cursor;
 #[test]
 fn test_ftp() {
     let future = async {
-        let mut ftp_stream = FtpStream::connect("192.168.1.60:21").await?;
+        let mut ftp_stream = FtpStream::connect(":::21").await?;
         let _ = ftp_stream.login("Doe", "mumble").await?;
 
         ftp_stream.mkdir("test_dir").await?;


### PR DESCRIPTION
This commit:

- updates tokio & tokio-rustls dependencies
- eliminates a compiler warning
- changes the integration test to look for the ftp server at ":::21"