### PR TITLE
fix: Vulnerability CVE-2020-26235

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ debug_print = []
 [dependencies]
 lazy_static = "1.4.0"
 regex = "1.3.9"
-chrono = "0.4.11"
+chrono = { version = "0.4.11", default-features = false, features = ["serde", "std"] }
 
 tokio = { version = "1.0.1", features = ["net", "io-util"] }
 tokio-rustls = { version = "0.23.0", optional = true }


### PR DESCRIPTION
This PR fixes vulnerability [CVE-2020-26235](https://nvd.nist.gov/vuln/detail/CVE-2020-26235).
It removes default features for chrono in order to eliminate subdependency on time@0.1.45.

Removing this subdependency is required by an advisory https://github.com/chronotope/chrono/issues/602.